### PR TITLE
REVIEW-ONLY PR: Add LOAS authentication as one of the Peer authentication methods

### DIFF
--- a/authentication/v1alpha1/policy.proto
+++ b/authentication/v1alpha1/policy.proto
@@ -205,6 +205,26 @@ message Jwt {
   repeated TriggerRule trigger_rules = 9;
 }
 
+
+// Other authentication
+message OtherAuthentication {
+  // identify the type of authentication
+  enum Type {
+     // ALTS
+     ALTS = 0;
+
+     // other custom
+     CUSTOM = 1;
+  };
+
+  Type type = 1;
+
+  // in case of CUSTOM, the name
+  string custom_name = 2;
+
+}
+
+
 // PeerAuthenticationMethod defines one particular type of authentication, e.g
 // mutual TLS, JWT etc, (no authentication is one type by itself) that can
 // be used for peer authentication.
@@ -218,6 +238,9 @@ message PeerAuthenticationMethod {
     // $hide_from_docs
     // Set if JWT is used. This option is not yet available.
     Jwt jwt = 2;
+
+    // Set if other auth used
+    OtherAuthentication other = 3;
   }
 }
 

--- a/mesh/v1alpha1/config.proto
+++ b/mesh/v1alpha1/config.proto
@@ -28,8 +28,8 @@ package istio.mesh.v1alpha1;
 
 option go_package="istio.io/api/mesh/v1alpha1";
 
-// MeshConfig defines mesh-wide variables shared by all Envoy instances in the
-// Istio service mesh.
+// MeshConfig defines mesh-wide variables shared by all Envoy (or Managed gRPC)
+// instances in the Istio service mesh.
 //
 // NOTE: This configuration type should be used for the low-level global
 // configuration, such as component addresses and port numbers. It should not
@@ -38,7 +38,7 @@ option go_package="istio.io/api/mesh/v1alpha1";
 // and replaced with several individual configuration types (for example,
 // tracing configuration).
 message MeshConfig {
-  // Address of the server that will be used by the proxies for policy
+  // Address of the server that will be used by the proxies or MgRPC for policy
   // check calls. By using different names for mixerCheckServer and
   // mixerReportServer, it is possible to have one set of mixer servers handle
   // policy check calls while another set of mixer servers handle telemetry
@@ -61,11 +61,11 @@ message MeshConfig {
   // to connect to Mixer.
   bool policy_check_fail_open = 25;
 
-  // Enable session affinity for envoy mixer reports so that calls from a proxy will
+  // Enable session affinity for envoy/MgRPC mixer reports so that calls will
   // always target the same mixer instance.
   bool sidecar_to_telemetry_session_affinity = 30;
 
-  // Port on which Envoy should listen for incoming connections from
+  // Port on which Envoy or MgRPC should listen for incoming connections from
   // other services.
   int32 proxy_listen_port = 4;
 
@@ -112,6 +112,7 @@ message MeshConfig {
   enum AuthPolicy {
     NONE = 0;
     MUTUAL_TLS = 1;
+    CUSTOM = 2;  // e.g. ALTS
   }
 
   // $hide_from_docs
@@ -146,6 +147,7 @@ message MeshConfig {
   // In case of Kubernetes, the proxy config is applied once during the injection process,
   // and remain constant for the duration of the pod. The rest of the mesh config can be changed
   // at runtime and config gets distributed dynamically.
+  // In proxyless mode this config applies to MgRPC as a default config
   ProxyConfig default_config = 14;
 
   reserved 15;
@@ -183,7 +185,7 @@ message MeshConfig {
   // Enables clide side policy checks.
   bool enable_client_side_policy_check = 19;
 
-  // Unix Domain Socket through which envoy communicates with NodeAgent SDS to get key/cert for mTLS.
+  // Unix Domain Socket through which envoy (or MgRPC) communicates with NodeAgent SDS to get key/cert for mTLS.
   // Use secret-mount files instead of SDS if set to empty.
   string sds_uds_path = 20;
 

--- a/mesh/v1alpha1/network.proto
+++ b/mesh/v1alpha1/network.proto
@@ -65,7 +65,7 @@ message Network {
 
   // The gateway associated with this network. Traffic from remote networks
   // will arrive at the specified gateway:port. All incoming traffic must
-  // use mTLS.
+  // use mTLS or similar encypted connection (e.g. ALTS).
   message IstioNetworkGateway {
     oneof gw {
       // A fully qualified domain name of the gateway service.  Pilot will
@@ -86,6 +86,9 @@ message Network {
 
     // The locality associated with an explicitly specified gateway (i.e. ip)
     string locality = 4;
+
+    // optional: encryption type if not mTLS (e.g. "ALTS")
+    string encryption_type = 5;
   }
 
   // REQUIRED: Set of gateways associated with the network.

--- a/mesh/v1alpha1/proxy.proto
+++ b/mesh/v1alpha1/proxy.proto
@@ -20,20 +20,31 @@ package istio.mesh.v1alpha1;
 
 option go_package="istio.io/api/mesh/v1alpha1";
 
-// AuthenticationPolicy defines authentication policy. It can be set for
+// AuthenticationPolicyKind defines authentication policy. It can be set for
 // different scopes (mesh, service …), and the most narrow scope with
 // non-INHERIT value will be used.
 // Mesh policy cannot be INHERIT.
-enum AuthenticationPolicy {
+enum AuthenticationPolicyKind {
   // Do not encrypt Envoy to Envoy traffic.
   NONE = 0;
 
   // Envoy to Envoy traffic is wrapped into mutual TLS connections.
   MUTUAL_TLS = 1;
 
+  // Envoy to Envoy traffic is wrapped into another encrypted connection (e.g. ALTS)
+  CUSTOM_ENCRYPTION = 2;
+
   // Use the policy defined by the parent scope. Should not be used for mesh
   // policy.
   INHERIT = 1000;
+}
+
+message AuthenticationPolicy {
+  // which authentication policy is being used
+  AuthenticationPolicyKind kind = 1;
+
+  // actual name in case kind is CUSTOM_ENCRYPTION e.g. "ALTS"
+  string custom_name = 2;
 }
 
 // Tracing defines configuration for the tracing performed by Envoy instances.
@@ -78,7 +89,8 @@ message Tracing {
 }
 
 
-// ProxyConfig defines variables for individual Envoy instances.
+// ProxyConfig defines variables for individual Envoy instances when Envoy is present
+// In proxyless mode Envoy is not present but some of these settings will be used
 message ProxyConfig {
   // Path to the generated configuration file directory.
   // Proxy agent generates the actual configuration and stores it in this directory.
@@ -165,9 +177,12 @@ message ProxyConfig {
     // filtering and manipulation. This mode also configures the sidecar to run with the
     // CAP_NET_ADMIN capability, which is required to use TPROXY.
     TPROXY = 1;
+
+    // In proxyless mode there is no redirection needed since there is no Envoy proxy!
+    NONE = 2;
   }
 
-  // The mode used to redirect inbound traffic to Envoy.
+  // The mode used to redirect inbound traffic to Envoy (when Envoy is present).
   InboundInterceptionMode interception_mode = 18;
 
   // Tracing configuration to be used by the proxy.

--- a/networking/v1alpha3/destination_rule.proto
+++ b/networking/v1alpha3/destination_rule.proto
@@ -138,8 +138,8 @@ message TrafficPolicy {
   // Settings controlling eviction of unhealthy hosts from the load balancing pool
   OutlierDetection outlier_detection = 3;
 
-  // TLS related settings for connections to the upstream service.
-  TLSSettings tls = 4;
+  // Encryption related settings for connections to the upstream service.
+  EncryptionSetting encryption = 4;
 
   // Traffic policies that apply to specific ports of the service
   message PortTrafficPolicy {
@@ -161,8 +161,8 @@ message TrafficPolicy {
     // Settings controlling eviction of unhealthy hosts from the load balancing pool
     OutlierDetection outlier_detection = 4;
 
-    // TLS related settings for connections to the upstream service.
-    TLSSettings tls = 5;
+    // Encryption related settings for connections to the upstream service.
+    EncryptionSetting encryption = 5;
   }
 
   // Traffic policies specific to individual ports. Note that port level
@@ -582,4 +582,32 @@ message TLSSettings {
 
   // SNI string to present to the server during TLS handshake.
   string sni = 6;
+}
+
+// Other encryption (other than TLS)
+message OtherEncryption {
+  // identify the type of encryption
+  enum Type {
+     // ALTS
+     ALTS = 0;
+
+     // other custom
+     CUSTOM = 1;
+  };
+
+  Type type = 1;
+
+  // in case of CUSTOM, the name
+  string custom_name = 2;
+
+}
+
+message EncryptionSetting {
+  oneof params {
+    // Set if TLS is used.
+    TLSSettings tls = 1;
+
+    // Set if other encryption used
+    OtherEncryption other = 2;
+  }
 }


### PR DESCRIPTION
show how a Istio control API proto is modified to enable prod support and proxyless support